### PR TITLE
aws-lambda commit

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -1,0 +1,44 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/archive" {
+  version = "2.7.1"
+  hashes = [
+    "h1:A7EnRBVm4h9ryO9LwxYnKr4fy7ExPMwD5a1DsY7m1Y0=",
+    "zh:19881bb356a4a656a865f48aee70c0b8a03c35951b7799b6113883f67f196e8e",
+    "zh:2fcfbf6318dd514863268b09bbe19bfc958339c636bcbcc3664b45f2b8bf5cc6",
+    "zh:3323ab9a504ce0a115c28e64d0739369fe85151291a2ce480d51ccbb0c381ac5",
+    "zh:362674746fb3da3ab9bd4e70c75a3cdd9801a6cf258991102e2c46669cf68e19",
+    "zh:7140a46d748fdd12212161445c46bbbf30a3f4586c6ac97dd497f0c2565fe949",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:875e6ce78b10f73b1efc849bfcc7af3a28c83a52f878f503bb22776f71d79521",
+    "zh:b872c6ed24e38428d817ebfb214da69ea7eefc2c38e5a774db2ccd58e54d3a22",
+    "zh:cd6a44f731c1633ae5d37662af86e7b01ae4c96eb8b04144255824c3f350392d",
+    "zh:e0600f5e8da12710b0c52d6df0ba147a5486427c1a2cc78f31eea37a47ee1b07",
+    "zh:f21b2e2563bbb1e44e73557bcd6cdbc1ceb369d471049c40eb56cb84b6317a60",
+    "zh:f752829eba1cc04a479cf7ae7271526b402e206d5bcf1fcce9f535de5ff9e4e6",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/lambda.tf
+++ b/lambda.tf
@@ -1,0 +1,118 @@
+# CI/CD側でlambdaのソースコードを格納するための箱
+# resource "aws_s3_bucket" "lambda_artifacts" {
+#   # AWS S3 で一意である(重複がない)必要がある
+#   # 例) kdg-aws-2025-ここに自分のgithubのユーザー名-lambda-artifacts
+#   bucket = "aws-2025-hiramoto-lambda-artifacts"
+#   tags = {
+#     # bucket に指定した内容と同じものを書く
+#     Name = "aws-2025-hiramoto-lambda-artifacts"
+#   }
+# }
+
+# lambda 実行時に必要な権限をまとめる role を定義する
+resource "aws_iam_role" "lambda" {
+  name = "iam_for_lambda"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Action = "sts:AssumeRole",
+        Principal = {
+          Service = "lambda.amazonaws.com"
+        },
+        Effect = "Allow",
+        Sid    = ""
+      }
+    ]
+  })
+}
+
+# CloudWatch Logs への書き込み権限を 定義した role に対して付与する
+resource "aws_iam_role_policy_attachment" "lambda_logs" {
+  role       = aws_iam_role.lambda.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}
+
+# GetAccountSettings も実行時に必要な権限なので付与する
+resource "aws_iam_role_policy" "get_account_settings" {
+  name = "GetAccountSettingsPermission"
+  role = aws_iam_role.lambda.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action   = "lambda:GetAccountSettings"
+        Effect   = "Allow"
+        Resource = "*"
+      },
+    ]
+  })
+}
+
+# 初回のみ利用する Lambda のファイルを生成
+# data "archive_file" "initial_lambda_package" {
+#   type        = "zip"
+#   output_path = "${path.module}/.temp_files/lambda.zip"
+#   source {
+#     # 実際に動作するPythonコードに修正
+#     content = <<EOF
+# import json
+
+# def lambda_handler(event, context):
+#     return {
+#         'statusCode': 200,
+#         'headers': {
+#             'Content-Type': 'application/json'
+#         },
+#         'body': json.dumps({
+#             'message': 'Hello from Lambda!',
+#             'function_name': context.function_name,
+#             'request_id': context.aws_request_id,
+#             'event': event
+#         })
+#     }
+# EOF
+#     filename = "lambda_function.py"
+#   }
+# }
+
+# (初回のみ)LambdaのファイルをS3にアップロード
+# resource "aws_s3_object" "lambda_file" {
+#   bucket = aws_s3_bucket.lambda_artifacts.id
+#   key    = "initial.zip"
+#   source = data.archive_file.initial_lambda_package.output_path
+# }
+
+# Lambda関数を生成
+# resource "aws_lambda_function" "first_function" {
+#   function_name = "first-function"
+#   role          = aws_iam_role.lambda.arn
+#   handler       = "lambda_function.lambda_handler"
+#   runtime       = "python3.12"
+#   timeout       = 120
+#   publish       = true
+#   s3_bucket     = aws_s3_bucket.lambda_artifacts.id
+#   s3_key        = aws_s3_object.lambda_file.key
+#   depends_on = [aws_s3_object.lambda_file]
+# }
+
+# 外部からリクエストを飛ばすためのエンドポイント
+# resource "aws_lambda_function_url" "first_function" {
+#   function_name      = aws_lambda_function.first_function.function_name
+#   authorization_type = "NONE"
+# }
+
+# 出力値を追加
+# output "lambda_function_url" {
+#   value = aws_lambda_function_url.first_function.function_url
+# }
+
+# output "lambda_function_name" {
+#   value = aws_lambda_function.first_function.function_name
+# }
+
+# output "s3_bucket_name" {
+#   value = aws_s3_bucket.lambda_artifacts.id
+# }

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_version = ">= 1.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = "ap-northeast-1"  # 東京リージョン
+} 


### PR DESCRIPTION
## なぜやるか

- Lambdaの実行環境をTerraformで管理するため

## なにをやったのか

- main.tfにTerraformとAWSプロバイダーの設定を追加（東京リージョン使用）
- Lambda実行用のIAMロール作成設定を追加
- CloudWatch Logsへの書き込み権限をIAMロールに付与
- Lambda関数のGetAccountSettings権限を設定

## 動作確認の手順
 1. Terraformの初期化
`terraform init`

2. 設定の確認
`terraform plan`

3. IAMロールの作成
`terraform apply`(yesを入力)

4. リソースの削除
`terraform destroy `