### PR TITLE
aws ec2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,18 @@ env/
 # OS
 .DS_Store
 Thumbs.db 
+
+# Terraform
+.terraform/*
+terraform.tfvars
+*.tfstate
+*.tfstate.*
+*.tfstate.backup
+
+# SSH keys and credentials
+*.pem
+*.key
+id_rsa
+id_rsa.pub
+.aws/
+*.credentials

--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -1,0 +1,24 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "6.3.0"
+  hashes = [
+    "h1:p8RNhYsu0ewxz13m4nNmc/gXB9tfn9b3d2KKdj91T5g=",
+    "zh:0502dc1889cca94c89bfc00b214970bffa2d81a2cdb55e05ab6192484ddb1532",
+    "zh:0a009c6f643410dc29fe2c07aee57e726ac86335fad84788fc7412abbd3a55be",
+    "zh:0ddd577e5f23dc0be23b87d62dff1f5694b88b1fbc01bdd3046b4b51cc18a00c",
+    "zh:1b2754cb01fa2c1a6a59c4195212f6bd4b3d1602e3f4ffb94ab609e01f2ea11a",
+    "zh:2bc0edb35a1411670d74e827db58ef32a07e11757fdaa17934dce5451511e55a",
+    "zh:703415b5c58d9232bdb686816e90525dfe96b0a374062bd8e27bec553cac5538",
+    "zh:8c4f1f41722aacb4b128dfb269f5b3f0aa1239a5742f22abb012f87095b2244c",
+    "zh:9815c0cc480acfef7c9b6b31505070bb0247a0982d98b4b6e51b1923b3a65f7e",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:b3563ce1e4c40fa139c045a1db06c3308fcf8aa9722c0a586a18bfbcedc111b5",
+    "zh:bbcf01aa5188416cb0f31425c2dfc3a4df41248d4dce9ebab709d416177a3011",
+    "zh:bc49559699e6a03ff57675172fc367db9993df74a502e0c6f273127af82990a9",
+    "zh:c89bbeee5db6bbe80ce152481b85a4d44b733d7c1e1a37924f36c9cde0b7ce2d",
+    "zh:d26793472e127a98dfa5d32a71adc4c960b573afc427604c9815bae9cda31a72",
+    "zh:eb8db004ccbf52b3ed8b15189c59560c233abd2c2f5ac5ee68768841c3c8e206",
+  ]
+}

--- a/ec2.tf
+++ b/ec2.tf
@@ -1,0 +1,34 @@
+# https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance
+data "aws_ami" "ubuntu" {
+  most_recent = true
+
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-*"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  owners = ["099720109477"] # Canonical
+}
+
+resource "aws_key_pair" "honahuku_thinkpad_20250621" {
+  key_name   = "honahuku_thinkpad_20250621"
+  public_key = file("~/.ssh/id_rsa.pub")
+}
+
+resource "aws_instance" "kdg-aws-20250621" {
+  ami = data.aws_ami.ubuntu.id
+  # AWS の無力枠を使いたいため t3.micro を使う
+  instance_type = "t3.micro"
+
+  tags = {
+    Name = "kdg-aws-20250621",
+  }
+  vpc_security_group_ids = [aws_security_group.ssh_enable.id]
+  key_name = aws_key_pair.honahuku_thinkpad_20250621.key_name
+}
+

--- a/vpc.tf
+++ b/vpc.tf
@@ -1,0 +1,42 @@
+variable "vpc_id" {
+  description = "vpc-0adabba7c83abd69a"
+  type        = string
+}
+
+data "aws_vpc" "main" {
+  default = true
+}
+
+resource "aws_security_group" "ssh_enable" {
+  vpc_id = data.aws_vpc.main.id
+  name   = "ssh-enable"
+  tags = {
+    Name = "ssh-enable",
+  }
+}
+
+resource "aws_vpc_security_group_egress_rule" "any" {
+  security_group_id = aws_security_group.ssh_enable.id
+
+  cidr_ipv4 = "0.0.0.0/0"
+  # any
+  ip_protocol = "-1"
+
+  tags = {
+    Name = "any",
+  }
+}
+
+resource "aws_vpc_security_group_ingress_rule" "ssh_enable" {
+
+  security_group_id = aws_security_group.ssh_enable.id
+
+  cidr_ipv4   = "0.0.0.0/0"
+  from_port   = 22
+  ip_protocol = "tcp"
+  to_port     = 22
+
+  tags = {
+    Name = "ssh-enable",
+  }
+}


### PR DESCRIPTION
## なぜやるか

- EC2インスタンスをTerraformで管理し、インフラをコード化するため
- SSH接続でサーバー操作できる環境を構築するため

## なにをやったのか

- TerraformでAWS EC2インスタンスの作成設定を追加
- SSH接続用のキーペア管理をTerraformで自動化
- セキュリティグループでSSHのアクセス許可設定を追加
- 既存のデフォルトVPCを利用したネットワーク設定
- .gitignoreにTerraform状態ファイルとSSH秘密鍵の除外設定を追加

## 動作確認の手順
1. Terraformの初期化
`terraform init`

2. 実行計画の確認
`terraform plan
`
3. インフラの作成
`terraform apply`
("yes"を入力して実行)

4. SSH接続の確認
AWSコンソールでパブリックIPを確認後、以下を実行
`ssh -i ~/.ssh/id_rsa ubuntu@<パブリックIP>`

5. リソースの削除
`terraform destroy`
( "yes"を入力して実行)