### PR TITLE
Aws alert

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,17 @@ env/
 # OS
 .DS_Store
 Thumbs.db 
+
+# Terraform
+.terraform/
+*.tfstate
+*.tfstate.backup
+*.tfvars
+*.tfplan
+crash.log
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+.terraformrc
+terraform.rc

--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -1,0 +1,24 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "6.3.0"
+  hashes = [
+    "h1:p8RNhYsu0ewxz13m4nNmc/gXB9tfn9b3d2KKdj91T5g=",
+    "zh:0502dc1889cca94c89bfc00b214970bffa2d81a2cdb55e05ab6192484ddb1532",
+    "zh:0a009c6f643410dc29fe2c07aee57e726ac86335fad84788fc7412abbd3a55be",
+    "zh:0ddd577e5f23dc0be23b87d62dff1f5694b88b1fbc01bdd3046b4b51cc18a00c",
+    "zh:1b2754cb01fa2c1a6a59c4195212f6bd4b3d1602e3f4ffb94ab609e01f2ea11a",
+    "zh:2bc0edb35a1411670d74e827db58ef32a07e11757fdaa17934dce5451511e55a",
+    "zh:703415b5c58d9232bdb686816e90525dfe96b0a374062bd8e27bec553cac5538",
+    "zh:8c4f1f41722aacb4b128dfb269f5b3f0aa1239a5742f22abb012f87095b2244c",
+    "zh:9815c0cc480acfef7c9b6b31505070bb0247a0982d98b4b6e51b1923b3a65f7e",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:b3563ce1e4c40fa139c045a1db06c3308fcf8aa9722c0a586a18bfbcedc111b5",
+    "zh:bbcf01aa5188416cb0f31425c2dfc3a4df41248d4dce9ebab709d416177a3011",
+    "zh:bc49559699e6a03ff57675172fc367db9993df74a502e0c6f273127af82990a9",
+    "zh:c89bbeee5db6bbe80ce152481b85a4d44b733d7c1e1a37924f36c9cde0b7ce2d",
+    "zh:d26793472e127a98dfa5d32a71adc4c960b573afc427604c9815bae9cda31a72",
+    "zh:eb8db004ccbf52b3ed8b15189c59560c233abd2c2f5ac5ee68768841c3c8e206",
+  ]
+}

--- a/budget.tf
+++ b/budget.tf
@@ -1,0 +1,31 @@
+variable "notification_email" {
+  description = "Budget alerts will be sent to this email address."
+  type        = string
+}
+
+resource "aws_budgets_budget" "monthly_budget" {
+  name         = "monthly-budget"
+  budget_type  = "COST"
+  limit_amount = "5"
+  limit_unit   = "USD"
+  time_unit    = "MONTHLY"
+
+  notification {
+    comparison_operator        = "GREATER_THAN"
+    threshold                  = 5
+    threshold_type             = "ABSOLUTE_VALUE"
+    notification_type          = "ACTUAL"
+    subscriber_email_addresses = [var.notification_email]
+    subscriber_sns_topic_arns  = [aws_sns_topic.budget_alerts.arn]
+  }
+}
+
+resource "aws_sns_topic" "budget_alerts" {
+  name = "budget-alerts"
+}
+
+resource "aws_sns_topic_subscription" "email_subscription" {
+  topic_arn = aws_sns_topic.budget_alerts.arn
+  protocol  = "email"
+  endpoint  = var.notification_email
+}


### PR DESCRIPTION

## なぜやるか

- AWS利用料金の予期しない高額請求を防ぐため
- 月額5ドルの予算上限を設定し、コスト管理を自動化するため

## なにをやったのか

- AWS Budgets設定をTerraformで追加（月額5ドル上限）
- 予算超過時のメール通知機能を実装
- SNSを使った通知システムを構築

## 動作確認の手順
1. 通知メールアドレスを設定
`export TF_VAR_notification_email="your-email@example.com"`

2. Terraformの初期化
`terraform init`
3. 実行計画の確認
`terraform plan `
4. インフラの作成
`terraform apply`
("yes"を入力して実行)